### PR TITLE
Fix for IndexOutOfBoundsException crashes in ItemTooltipEventHandler

### DIFF
--- a/src/main/java/nova/committee/enhancedarmaments/init/handler/ItemTooltipEventHandler.java
+++ b/src/main/java/nova/committee/enhancedarmaments/init/handler/ItemTooltipEventHandler.java
@@ -103,20 +103,30 @@ public class ItemTooltipEventHandler {
 
     private static void changeTooltips(List<Component> tooltip, ItemStack stack, Rarity rarity) {
         // rarity after the name
-        tooltip.set(0, Component.literal(stack.getDisplayName().getString() + rarity.getColor() + " (" + ChatFormatting.ITALIC + I18n.get("enhancedarmaments.rarity." + rarity.getName()) + ")"));
-
+        // Fix: Check if tooltip list is empty before attempting to set index 0
+        if (!tooltip.isEmpty()) {
+            tooltip.set(0, Component.literal(stack.getDisplayName().getString() + rarity.getColor() + " (" + ChatFormatting.ITALIC + I18n.get("enhancedarmaments.rarity." + rarity.getName()) + ")"));
+        }
+        
         if (EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.mainHand")) && !(stack.getItem() instanceof BowItem)) {
             Multimap<Attribute, AttributeModifier> map = stack.getItem().getAttributeModifiers(EquipmentSlot.MAINHAND, stack);
             Collection<AttributeModifier> damageCollection = map.get(Attributes.ATTACK_DAMAGE);
-            
-            // Add this check
+
+            // Fix: Check if damageCollection is empty before accessing first element
             if (!damageCollection.isEmpty()) {
                 AttributeModifier damageModifier = (AttributeModifier) damageCollection.toArray()[0];
                 double damage = ((damageModifier.getAmount() + 1) * rarity.getEffect()) + damageModifier.getAmount() + 1;
                 String d = String.format("%.1f", damage);
-        
-                if (rarity.getEffect() != 0)
-                    tooltip.set(EAUtil.lineContainsString(tooltip, I18n.get("enhancedarmaments.misc.pos.mainHand")) + 2, Component.literal(rarity.getColor() + " " + d + ChatFormatting.GRAY + " " + I18n.get("enhancedarmaments.misc.tooltip.attackdamage")));
+              
+                // Fix: Check if calculated index is within bounds before using set()
+                if (rarity.getEffect() != 0) {
+                    int targetIndex = EAUtil.lineContainsString(tooltip, I18n.get("enhancedarmaments.misc.pos.mainHand")) + 2;
+                    if (targetIndex < tooltip.size()) {
+                        tooltip.set(targetIndex, Component.literal(rarity.getColor() + " " + d + ChatFormatting.GRAY + " " + I18n.get("enhancedarmaments.misc.tooltip.attackdamage")));
+                    } else {
+                        tooltip.add(Component.literal(rarity.getColor() + " " + d + ChatFormatting.GRAY + " " + I18n.get("enhancedarmaments.misc.tooltip.attackdamage")));
+                    }
+                }
             }
         }
 
@@ -132,13 +142,27 @@ public class ItemTooltipEventHandler {
                 line = EAUtil.lineContainsString(tooltip, I18n.get("enhancedarmaments.misc.pos.legs"));
             if (EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.feet")))
                 line = EAUtil.lineContainsString(tooltip, I18n.get("enhancedarmaments.misc.pos.feet"));
-            if (percentage != 0)
-                tooltip.add(line + 1, Component.literal(" " + ChatFormatting.BLUE + "+" + rarity.getColor() + percentage + ChatFormatting.BLUE + "% " + I18n.get("enhancedarmaments.misc.rarity.armorreduction")));
+            
+            // Fix: Check bounds before adding to specific index in armor section
+            if (percentage != 0) {
+                int targetIndex = line + 1;
+                if (targetIndex <= tooltip.size()) {
+                    tooltip.add(targetIndex, Component.literal(" " + ChatFormatting.BLUE + "+" + rarity.getColor() + percentage + ChatFormatting.BLUE + "% " + I18n.get("enhancedarmaments.misc.rarity.armorreduction")));
+                } else {
+                    tooltip.add(Component.literal(" " + ChatFormatting.BLUE + "+" + rarity.getColor() + percentage + ChatFormatting.BLUE + "% " + I18n.get("enhancedarmaments.misc.rarity.armorreduction")));
+                }
+            }
         }
 
         if (EAUtil.canEnhanceRanged(stack.getItem()) && rarity.getEffect() != 0) {
             String b = String.format("%.1f", rarity.getEffect() / 3 * 100);
-            tooltip.add(1, Component.literal(I18n.get("enhancedarmaments.misc.rarity.arrowpercentage") + " " + rarity.getColor() + "+" + b + "%"));
+
+            // Fix: Check if tooltip has enough elements before inserting at index 1
+            if (tooltip.size() > 1) {
+                tooltip.add(1, Component.literal(I18n.get("enhancedarmaments.misc.rarity.arrowpercentage") + " " + rarity.getColor() + "+" + b + "%"));
+            } else {
+                tooltip.add(Component.literal(I18n.get("enhancedarmaments.misc.rarity.arrowpercentage") + " " + rarity.getColor() + "+" + b + "%"));
+            }
         }
     }
 }

--- a/src/main/java/nova/committee/enhancedarmaments/init/handler/ItemTooltipEventHandler.java
+++ b/src/main/java/nova/committee/enhancedarmaments/init/handler/ItemTooltipEventHandler.java
@@ -108,12 +108,16 @@ public class ItemTooltipEventHandler {
         if (EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.mainHand")) && !(stack.getItem() instanceof BowItem)) {
             Multimap<Attribute, AttributeModifier> map = stack.getItem().getAttributeModifiers(EquipmentSlot.MAINHAND, stack);
             Collection<AttributeModifier> damageCollection = map.get(Attributes.ATTACK_DAMAGE);
-            AttributeModifier damageModifier = (AttributeModifier) damageCollection.toArray()[0];
-            double damage = ((damageModifier.getAmount() + 1) * rarity.getEffect()) + damageModifier.getAmount() + 1;
-            String d = String.format("%.1f", damage);
-
-            if (rarity.getEffect() != 0)
-                tooltip.set(EAUtil.lineContainsString(tooltip, I18n.get("enhancedarmaments.misc.pos.mainHand")) + 2, Component.literal(rarity.getColor() + " " + d + ChatFormatting.GRAY + " " + I18n.get("enhancedarmaments.misc.tooltip.attackdamage")));
+            
+            // Add this check
+            if (!damageCollection.isEmpty()) {
+                AttributeModifier damageModifier = (AttributeModifier) damageCollection.toArray()[0];
+                double damage = ((damageModifier.getAmount() + 1) * rarity.getEffect()) + damageModifier.getAmount() + 1;
+                String d = String.format("%.1f", damage);
+        
+                if (rarity.getEffect() != 0)
+                    tooltip.set(EAUtil.lineContainsString(tooltip, I18n.get("enhancedarmaments.misc.pos.mainHand")) + 2, Component.literal(rarity.getColor() + " " + d + ChatFormatting.GRAY + " " + I18n.get("enhancedarmaments.misc.tooltip.attackdamage")));
+            }
         }
 
         if (EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.head")) || EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.body")) || EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.legs")) || EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.feet"))) {


### PR DESCRIPTION
Yes, you should update the PR description to reflect all the fixes. Here's an updated version:

Fix Multiple IndexOutOfBoundsException crashes in ItemTooltipEventHandler
Problem
The mod crashes when modifying tooltips due to multiple unchecked array/list accesses:

Line 103: Setting index 0 when tooltip list might be empty
Line 111: Accessing damageCollection.toArray()[0] when the collection is empty
Line 116: Calling tooltip.set(index, ...) when the calculated index exceeds list size
Line 138: Adding to armor tooltip at an index that may exceed list bounds
Line 147: Inserting at index 1 for ranged weapons when tooltip may have fewer elements

These crashes occur when Enhanced Armaments interacts with items that have non-standard attribute modifiers or when other mods alter tooltip structure.
Solution
Added comprehensive bounds checking throughout the changeTooltips method:

Check if tooltip list is not empty before setting index 0
Verify damageCollection has elements before accessing
Validate all calculated indices are within bounds before using set() or add(index, ...)
Fall back to add() (append) when indices are out of range

Testing
Tested with:

Vanilla bows and weapons
Empty-handed tooltips
Various tooltip-modifying mods including Unique Enchantments Base, Legendary Tooltips, and Attribute Tooltip Fix

Affected Versions

Forge 1.19.2-1.1.3
Similar fixes likely needed for Fabric version

This fix ensures compatibility with other mods that modify item tooltips or attribute modifiers, preventing all identified crash scenarios without changing the mod's intended functionality.