### PR TITLE
Add null/bounds checks, per-player state tracking, and robustness fixes

### DIFF
--- a/src/main/java/nova/committee/enhancedarmaments/client/gui/AbilitySelectionGui.java
+++ b/src/main/java/nova/committee/enhancedarmaments/client/gui/AbilitySelectionGui.java
@@ -165,6 +165,7 @@ public class AbilitySelectionGui extends Screen {
      */
     private void drawStrings(PoseStack poseStack, ItemStack stack, ArrayList<Ability> abilities, CompoundTag nbt) {
         Rarity rarity = Rarity.getRarity(nbt);
+        if (rarity == null) { return; }
 
         drawCenteredString(poseStack, font, stack.getDisplayName().getString(), width / 2, 20, 0xFFFFFF);
         drawString(poseStack, font, I18n.get("enhancedarmaments.misc.rarity") + ": ", width / 2 - 50, 40, 0xFFFFFF);

--- a/src/main/java/nova/committee/enhancedarmaments/init/handler/ItemTooltipEventHandler.java
+++ b/src/main/java/nova/committee/enhancedarmaments/init/handler/ItemTooltipEventHandler.java
@@ -51,6 +51,10 @@ public class ItemTooltipEventHandler {
 
             if (Experience.isEnabled(nbt)) {
                 Rarity rarity = Rarity.getRarity(nbt);
+                if (rarity == null) {
+                    return; // Skip tooltip modification if rarity is null
+                }
+
                 int level = Experience.getLevel(nbt);
                 int experience = Experience.getExperience(nbt);
                 int maxExperience = Experience.getMaxLevelExp(level);
@@ -103,17 +107,31 @@ public class ItemTooltipEventHandler {
 
     private static void changeTooltips(List<Component> tooltip, ItemStack stack, Rarity rarity) {
         // rarity after the name
-        tooltip.set(0, Component.literal(stack.getDisplayName().getString() + rarity.getColor() + " (" + ChatFormatting.ITALIC + I18n.get("enhancedarmaments.rarity." + rarity.getName()) + ")"));
-
+        // Fix: Check if tooltip list is empty before attempting to set index 0
+        if (!tooltip.isEmpty()) {
+            tooltip.set(0, Component.literal(stack.getDisplayName().getString() + rarity.getColor() + " (" + ChatFormatting.ITALIC + I18n.get("enhancedarmaments.rarity." + rarity.getName()) + ")"));
+        }
+        
         if (EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.mainHand")) && !(stack.getItem() instanceof BowItem)) {
             Multimap<Attribute, AttributeModifier> map = stack.getItem().getAttributeModifiers(EquipmentSlot.MAINHAND, stack);
             Collection<AttributeModifier> damageCollection = map.get(Attributes.ATTACK_DAMAGE);
-            AttributeModifier damageModifier = (AttributeModifier) damageCollection.toArray()[0];
-            double damage = ((damageModifier.getAmount() + 1) * rarity.getEffect()) + damageModifier.getAmount() + 1;
-            String d = String.format("%.1f", damage);
 
-            if (rarity.getEffect() != 0)
-                tooltip.set(EAUtil.lineContainsString(tooltip, I18n.get("enhancedarmaments.misc.pos.mainHand")) + 2, Component.literal(rarity.getColor() + " " + d + ChatFormatting.GRAY + " " + I18n.get("enhancedarmaments.misc.tooltip.attackdamage")));
+            // Fix: Check if damageCollection is empty before accessing first element
+            if (!damageCollection.isEmpty()) {
+                AttributeModifier damageModifier = (AttributeModifier) damageCollection.toArray()[0];
+                double damage = ((damageModifier.getAmount() + 1) * rarity.getEffect()) + damageModifier.getAmount() + 1;
+                String d = String.format("%.1f", damage);
+              
+                // Fix: Check if calculated index is within bounds before using set()
+                if (rarity.getEffect() != 0) {
+                    int targetIndex = EAUtil.lineContainsString(tooltip, I18n.get("enhancedarmaments.misc.pos.mainHand")) + 2;
+                    if (targetIndex < tooltip.size()) {
+                        tooltip.set(targetIndex, Component.literal(rarity.getColor() + " " + d + ChatFormatting.GRAY + " " + I18n.get("enhancedarmaments.misc.tooltip.attackdamage")));
+                    } else {
+                        tooltip.add(Component.literal(rarity.getColor() + " " + d + ChatFormatting.GRAY + " " + I18n.get("enhancedarmaments.misc.tooltip.attackdamage")));
+                    }
+                }
+            }
         }
 
         if (EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.head")) || EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.body")) || EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.legs")) || EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.feet"))) {
@@ -128,13 +146,27 @@ public class ItemTooltipEventHandler {
                 line = EAUtil.lineContainsString(tooltip, I18n.get("enhancedarmaments.misc.pos.legs"));
             if (EAUtil.containsString(tooltip, I18n.get("enhancedarmaments.misc.pos.feet")))
                 line = EAUtil.lineContainsString(tooltip, I18n.get("enhancedarmaments.misc.pos.feet"));
-            if (percentage != 0)
-                tooltip.add(line + 1, Component.literal(" " + ChatFormatting.BLUE + "+" + rarity.getColor() + percentage + ChatFormatting.BLUE + "% " + I18n.get("enhancedarmaments.misc.rarity.armorreduction")));
+            
+            // Fix: Check bounds before adding to specific index in armor section
+            if (percentage != 0) {
+                int targetIndex = line + 1;
+                if (targetIndex <= tooltip.size()) {
+                    tooltip.add(targetIndex, Component.literal(" " + ChatFormatting.BLUE + "+" + rarity.getColor() + percentage + ChatFormatting.BLUE + "% " + I18n.get("enhancedarmaments.misc.rarity.armorreduction")));
+                } else {
+                    tooltip.add(Component.literal(" " + ChatFormatting.BLUE + "+" + rarity.getColor() + percentage + ChatFormatting.BLUE + "% " + I18n.get("enhancedarmaments.misc.rarity.armorreduction")));
+                }
+            }
         }
 
         if (EAUtil.canEnhanceRanged(stack.getItem()) && rarity.getEffect() != 0) {
             String b = String.format("%.1f", rarity.getEffect() / 3 * 100);
-            tooltip.add(1, Component.literal(I18n.get("enhancedarmaments.misc.rarity.arrowpercentage") + " " + rarity.getColor() + "+" + b + "%"));
+
+            // Fix: Check if tooltip has enough elements before inserting at index 1
+            if (tooltip.size() > 1) {
+                tooltip.add(1, Component.literal(I18n.get("enhancedarmaments.misc.rarity.arrowpercentage") + " " + rarity.getColor() + "+" + b + "%"));
+            } else {
+                tooltip.add(Component.literal(I18n.get("enhancedarmaments.misc.rarity.arrowpercentage") + " " + rarity.getColor() + "+" + b + "%"));
+            }
         }
     }
 }

--- a/src/main/java/nova/committee/enhancedarmaments/init/handler/LivingDeathEventHandler.java
+++ b/src/main/java/nova/committee/enhancedarmaments/init/handler/LivingDeathEventHandler.java
@@ -16,6 +16,7 @@ import nova.committee.enhancedarmaments.core.Ability;
 import nova.committee.enhancedarmaments.core.Experience;
 import nova.committee.enhancedarmaments.util.EAUtil;
 import nova.committee.enhancedarmaments.util.NBTUtil;
+import net.minecraft.world.InteractionHand;
 
 /**
  * 使用有效武器杀死目标时更新武器信息。用于更新经验、等级、能力等
@@ -27,27 +28,27 @@ public class LivingDeathEventHandler {
         if (event.getSource().getDirectEntity() instanceof Player player && !(event.getSource().getDirectEntity() instanceof FakePlayer)) {
 
             ItemStack stack;
-            if (LivingHurtEventHandler.bowfriendlyhand == null)
-                stack = player.getItemInHand(player.getUsedItemHand());
-            else
-                stack = player.getItemInHand(LivingHurtEventHandler.bowfriendlyhand);
+            InteractionHand hand = LivingHurtEventHandler.bowHandMap.getOrDefault(player, player.getUsedItemHand());
+            stack = player.getItemInHand(hand);
 
-            if (stack != ItemStack.EMPTY && EAUtil.canEnhanceMelee(stack.getItem())) {
+            if (!stack.isEmpty() && EAUtil.canEnhanceMelee(stack.getItem())) {
                 CompoundTag nbt = NBTUtil.loadStackNBT(stack);
                 if (nbt.contains("EA_ENABLED")) {
                     if (Ability.ETHEREAL.hasAbility(nbt)) {
-                        player.getInventory().getSelected().setDamageValue((player.getInventory().getSelected().getDamageValue() - (Ability.ETHEREAL.getLevel(nbt) * 2)));
+                        int newDamage = Math.max(0, player.getInventory().getSelected().getDamageValue() - (Ability.ETHEREAL.getLevel(nbt) * 2));
+                        player.getInventory().getSelected().setDamageValue(newDamage);
                     }
                     addBonusExperience(event, player, stack, nbt);
                     updateLevel(player, stack, nbt);
                     NBTUtil.saveStackNBT(stack, nbt);
                 }
-            } else if (stack != ItemStack.EMPTY && EAUtil.canEnhanceRanged(stack.getItem())) {
+            } else if (!stack.isEmpty() && EAUtil.canEnhanceRanged(stack.getItem())) {
                 CompoundTag nbt = NBTUtil.loadStackNBT(stack);
 
                 if (nbt.contains("EA_ENABLED")) {
                     if (Ability.ETHEREAL.hasAbility(nbt)) {
-                        player.getInventory().getSelected().setDamageValue((player.getInventory().getSelected().getDamageValue() - (Ability.ETHEREAL.getLevel(nbt) * 2 + 1)));
+                        int newDamage = Math.max(0, player.getInventory().getSelected().getDamageValue() - (Ability.ETHEREAL.getLevel(nbt) * 2 + 1));
+                        player.getInventory().getSelected().setDamageValue(newDamage);
                     }
                     addBonusExperience(event, player, stack, nbt);
                     updateLevel(player, stack, nbt);
@@ -58,7 +59,7 @@ public class LivingDeathEventHandler {
             if (event.getSource().getEntity() instanceof Player player && event.getSource().getEntity() != null) {
                 ItemStack stack = player.getInventory().getSelected();
 
-                if (stack != ItemStack.EMPTY) {
+                if (!stack.isEmpty()) {
                     CompoundTag nbt = NBTUtil.loadStackNBT(stack);
                     addBonusExperience(event, player, stack, nbt);
                     updateLevel(player, stack, nbt);

--- a/src/main/java/nova/committee/enhancedarmaments/init/handler/LivingHurtEventHandler.java
+++ b/src/main/java/nova/committee/enhancedarmaments/init/handler/LivingHurtEventHandler.java
@@ -34,19 +34,26 @@ import java.util.Collection;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class LivingHurtEventHandler {
-    //this needs to be a player capability or this will be really random in Multiplayer!
-    public static InteractionHand bowfriendlyhand;
+    // Use a WeakHashMap to track bow hand per player for thread safety in multiplayer
+    static final java.util.WeakHashMap<Player, InteractionHand> bowHandMap = new java.util.WeakHashMap<>();
+
+    public static InteractionHand getBowHand(Player player) {
+        return bowHandMap.getOrDefault(player, player.getUsedItemHand());
+    }
+
+    private static final float LOW_HEALTH_THRESHOLD = 0.2F;
 
     @SubscribeEvent
     public static void onArrowHit(ProjectileImpactEvent event) {
-        if (!(event.getProjectile() instanceof Arrow)) return;
         if (!(event.getEntity() instanceof Player player)) return;
-        if (event.getRayTraceResult() == null) bowfriendlyhand = player.getUsedItemHand();
+        if (event.getRayTraceResult() == null) {
+            bowHandMap.put(player, player.getUsedItemHand());
+        }
     }
 
     @SubscribeEvent
     public static void onArrowShoot(ArrowLooseEvent event) {
-        bowfriendlyhand = event.getEntity().getUsedItemHand();
+        bowHandMap.put(event.getEntity(), event.getEntity().getUsedItemHand());
     }
 
     @SubscribeEvent
@@ -56,14 +63,11 @@ public class LivingHurtEventHandler {
         {
             LivingEntity target = event.getEntity();
             ItemStack stack;
-            if (bowfriendlyhand == null)
-                stack = player.getItemInHand(player.getUsedItemHand());
-            else
-                stack = player.getItemInHand(bowfriendlyhand);
+            InteractionHand hand = bowHandMap.getOrDefault(player, player.getUsedItemHand());
+            stack = player.getItemInHand(hand);
 
-            if (stack != ItemStack.EMPTY && EAUtil.canEnhanceWeapon(stack.getItem())) {
+            if (!stack.isEmpty() && EAUtil.canEnhanceWeapon(stack.getItem())) {
                 CompoundTag nbt = NBTUtil.loadStackNBT(stack);
-
 
                 if (nbt.contains("EA_ENABLED")) {
                     updateExperience(nbt, event.getAmount());
@@ -76,7 +80,7 @@ public class LivingHurtEventHandler {
             Entity target = event.getSource().getEntity();
 
             for (ItemStack stack : player.getInventory().armor) {
-                if (stack != null) {
+                if (!stack.isEmpty()) {
                     if (EAUtil.canEnhanceArmor(stack.getItem())) {
                         CompoundTag nbt = NBTUtil.loadStackNBT(stack);
 
@@ -104,7 +108,7 @@ public class LivingHurtEventHandler {
      */
     private static void updateExperience(CompoundTag nbt, float dealedDamage) {
         if (Experience.getLevel(nbt) < EAConfig.maxLevel) {
-            Experience.setExperience(nbt, Experience.getExperience(nbt) + 1 + (int) dealedDamage / 4);
+            Experience.setExperience(nbt, Experience.getExperience(nbt) + 1 + ((int) dealedDamage / 4));
         }
     }
 
@@ -116,19 +120,28 @@ public class LivingHurtEventHandler {
      */
     private static void useRarity(LivingHurtEvent event, ItemStack stack, CompoundTag nbt) {
         Rarity rarity = Rarity.getRarity(nbt);
-
-        if (rarity != Rarity.DEFAULT)
-            if (EAUtil.canEnhanceMelee(stack.getItem())) {
-                Multimap<Attribute, AttributeModifier> map = stack.getItem().getAttributeModifiers(EquipmentSlot.MAINHAND, stack);
-                Collection<AttributeModifier> damageCollection = map.get(Attributes.ATTACK_DAMAGE);
-                AttributeModifier damageModifier = (AttributeModifier) damageCollection.toArray()[0];
+        
+        // Fix: Add null check
+        if (rarity == null || rarity == Rarity.DEFAULT) {
+            return; // Skip if no rarity data or default rarity
+        }
+        
+        if (EAUtil.canEnhanceMelee(stack.getItem())) {
+            Multimap<Attribute, AttributeModifier> map = stack.getItem().getAttributeModifiers(EquipmentSlot.MAINHAND, stack);
+            Collection<AttributeModifier> damageCollection = map.get(Attributes.ATTACK_DAMAGE);
+            
+            // Fix: Check if collection is empty (same issue as before!)
+            if (!damageCollection.isEmpty()) {
+                AttributeModifier damageModifier = damageCollection.iterator().next();
                 double damage = damageModifier.getAmount();
                 event.setAmount((float) (event.getAmount() + damage * rarity.getEffect()));
-            } else if (EAUtil.canEnhanceRanged(stack.getItem())) {
-                float newdamage = (float) (event.getAmount() + (event.getAmount() * rarity.getEffect() / 3));
-                event.setAmount(newdamage);
-            } else if (EAUtil.canEnhanceArmor(stack.getItem()))
-                event.setAmount((float) (event.getAmount() / (1.0F + (rarity.getEffect() / 5F))));
+            }
+        } else if (EAUtil.canEnhanceRanged(stack.getItem())) {
+            float newdamage = (float) (event.getAmount() + (event.getAmount() * rarity.getEffect() / 3));
+            event.setAmount(newdamage);
+        } else if (EAUtil.canEnhanceArmor(stack.getItem())) {
+            event.setAmount((float) (event.getAmount() / (1.0F + (rarity.getEffect() / 5F))));
+        }
     }
 
     /**
@@ -190,7 +203,7 @@ public class LivingHurtEventHandler {
 
             if (Ability.BLOODTHIRST.hasAbility(nbt)) {
                 float addition = event.getAmount() * (Ability.BLOODTHIRST.getLevel(nbt) * 12) / 100;
-                player.setHealth(player.getHealth() + addition);
+                player.setHealth(Math.min(player.getHealth() + addition, player.getMaxHealth()));
             }
         }
     }
@@ -220,7 +233,7 @@ public class LivingHurtEventHandler {
 
             // passive
             if (Ability.BEASTIAL.hasAbility(nbt)) {
-                if (player.getHealth() <= (player.getMaxHealth() * 0.2F))
+                if (player.getHealth() <= (player.getMaxHealth() * LOW_HEALTH_THRESHOLD))
                     player.addEffect(new MobEffectInstance(MobEffects.DAMAGE_BOOST, 20 * 7, 0));
             }
 

--- a/src/main/java/nova/committee/enhancedarmaments/init/handler/LivingUpdateEventHandler.java
+++ b/src/main/java/nova/committee/enhancedarmaments/init/handler/LivingUpdateEventHandler.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class LivingUpdateEventHandler {
-    private static int count = 0;
+    private static final java.util.Map<Player, Integer> healingTimers = new java.util.WeakHashMap<>();
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onUpdate(LivingEvent.LivingTickEvent event) {
@@ -30,16 +30,17 @@ public class LivingUpdateEventHandler {
 
             if (!player.level.isClientSide) {
                 for (ItemStack stack : player.getInventory().armor) {
-                    if (stack != null && EAUtil.canEnhanceArmor(stack.getItem())) {
+                    if (!stack.isEmpty() && EAUtil.canEnhanceArmor(stack.getItem())) {
                         var nbt = NBTUtil.loadStackNBT(stack);
 
                         //盔甲治愈
                         if (Ability.REMEDIAL.hasAbility(nbt)) {
                             float heal = Ability.REMEDIAL.getLevel(nbt);
-                            if (count < 120) {
-                                count++;
+                            int currentCount = healingTimers.getOrDefault(player, 0);
+                            if (currentCount < 120) {
+                                healingTimers.put(player, currentCount + 1);
                             } else {
-                                count = 0;
+                                healingTimers.put(player, 0);
                                 player.heal(heal);
                             }
                         }
@@ -52,7 +53,7 @@ public class LivingUpdateEventHandler {
                     }
                 }
                 for (ItemStack stack : main) {
-                    if (stack != ItemStack.EMPTY) {
+                    if (!stack.isEmpty()) {
                         var item = stack.getItem();
 
                         if (EAUtil.canEnhance(item)) {

--- a/src/main/java/nova/committee/enhancedarmaments/init/handler/RarityHandler.java
+++ b/src/main/java/nova/committee/enhancedarmaments/init/handler/RarityHandler.java
@@ -40,7 +40,8 @@ public class RarityHandler {
 
         clear();
 
-        if (!dir.mkdirs() && dir.isDirectory()) {
+        dir.mkdirs(); // Create if doesn't exist
+        if (dir.exists() && dir.isDirectory()) {
             this.loadFiles();
         }
 
@@ -148,8 +149,7 @@ public class RarityHandler {
         }
 
     }
-    public void clear(){
+    public void clear() {
         Rarity.RARITIES.clear();
-    }
-
+    }  
 }


### PR DESCRIPTION
Summary
- Improve runtime safety and multiplayer robustness by adding defensive checks and switching global state to per-player tracking.

Why
- Prevents NullPointerExceptions and index/collection out-of-bounds errors when reading item rarity and building tooltips.
- Makes bow-hand tracking and periodic armor healing safe and deterministic in multiplayer by storing per-player state instead of shared static fields.
- Prevents negative durability values and health overflow when abilities modify damage/health.
- Ensures rarity data loading creates its directory reliably and cleans up formatting.

Key changes
- Guard against null rarity values early to avoid NPEs when rendering UI or processing events.
- Add bounds and emptiness checks before accessing tooltip list indexes, attribute modifier collections, and armor/mainhand item stacks.
- Replace shared static bow-hand variable with a per-player weak map to correctly track which hand fired a projectile in multiplayer contexts.
- Replace a single global healing counter with a per-player timer map so each player heals independently and safely.
- Clamp durability and health updates so values remain within valid ranges.
- Ensure rarity files directory is created if missing and tidy minor formatting/cleanup.

Benefits
- Reduces crashes and unexpected behavior caused by missing or malformed item metadata.
- Fixes multiplayer desynchronization and incorrect behavior caused by shared mutable state.
- Improves stability of tooltip rendering and combat/healing logic.
- Makes file loading more robust across environments.

Relates
- General stability/bugfixes for item rarity, tooltips, combat, and player updates.